### PR TITLE
Load overrides into $settings not $settings['settings']

### DIFF
--- a/files/settings.dist
+++ b/files/settings.dist
@@ -22,7 +22,7 @@ $settings_drupal = array_filter(
 foreach ($settings_drupal as $name => $value) {
   if (substr($name, 0, 9) === 'SETTINGS_') {
     $key = strtolower(substr($name, 9));
-    $settings['settings'][$key] = $value;
+    $settings[$key] = $value;
   }
 }
 


### PR DESCRIPTION
I'm unsure if this changes your intended behaviour but I suspect it might be a bug.

Before this change, adding `SETTINGS_FILE_PRIVATE_PATH="/path/to/dir"` in .env will create the new value `$settings['settings']['file_private_path'] = '/path/to/dir'`. 

This small change just ensures it overrides/adds the actual setting at `$settings['file_private_path']`.